### PR TITLE
Added mojang's server

### DIFF
--- a/loader/interfaces/__init__.py
+++ b/loader/interfaces/__init__.py
@@ -1,3 +1,4 @@
 from json_loader import *
 from jenkins_loader import *
 from craftbukkit_loader import *
+from mojang_loader import *

--- a/loader/interfaces/mojang_loader.py
+++ b/loader/interfaces/mojang_loader.py
@@ -1,0 +1,41 @@
+import urllib2, json
+
+class loader_mojang:
+
+	url = 'http://s3.amazonaws.com/Minecraft.Download/versions/versions.json'
+	download_url_base = 'https://s3.amazonaws.com/Minecraft.Download/versions/{0}/minecraft_server.{0}.jar'
+
+	def getJSON(self):
+		response = urllib2.urlopen(self.url)
+		return json.loads(response.read())
+
+	def create_build_numbers(self, builds):
+		numbers = dict()
+		builds.sort(key=lambda b: b['releaseTime'])
+		counter = 1
+		for build in builds:
+			numbers[build['id']] = counter
+			counter += 1
+		return numbers
+
+	def load(self, channel, last_build):
+		data = self.getJSON()
+
+		build_numbers = self.create_build_numbers(data['versions'])
+
+		builds = []
+		for build in data['versions']:
+			if build['type'] != channel['name']: continue
+
+			build_number = build_numbers[build['id']]
+			if build_number <= last_build: continue
+
+			builds.append({
+				'version': build['id'],
+				'size': None,
+				'checksum': None,
+				'url': self.download_url_base.format(build['id']),
+				'build': build_number
+			})
+
+		return builds

--- a/sources/mojang.json
+++ b/sources/mojang.json
@@ -1,0 +1,27 @@
+{
+    "name": "mojang",
+    "site_url": "http://www.minecraft.net/",
+    "description": "Vanilla Minecraft server, as created by Mojang.",
+    "channels": [
+        {
+            "name": "snapshot",
+            "interface": "mojang",
+            "mirror": false
+        },
+        {
+            "name": "release",
+            "interface": "mojang",
+            "mirror": false
+        },
+        {
+            "name": "old_alpha",
+            "interface": "mojang",
+            "mirror": false
+        },
+        {
+            "name": "old_beta",
+            "interface": "mojang",
+            "mirror": false
+        }
+    ]
+}


### PR DESCRIPTION
It works well, but because Mojang doesn't provide build numbers those have to be generated each time the loader is ran. It should work when new updates are released, but I haven't had the chance to test that.

The only way to get past this problem is to allow the build column in the build model to be a string and not just a integer. Alternative a list of the previously added builds could be passed to the load method, and then we would only need to generate the ids for the new builds.
